### PR TITLE
Add simple ENet server/client example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(GameCore INTERFACE)
 target_include_directories(GameCore INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/Source          # your own headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/Include         # third-party headers
 )
 
 target_include_directories(GameCore SYSTEM INTERFACE
@@ -55,6 +56,9 @@ if (WIN32)
     )
     set(ESENTHEL_ENGINE_LIB EsenthelEngine)
 
+    # ENet library for Windows
+    set(ENET_LIB "${CMAKE_CURRENT_SOURCE_DIR}/Lib/enet64.lib")
+
     ## ── Full Windows-SDK + DirectX import-library set (matches old VS cfg) ─
     ##    x3daudio1_7.lib is created by the stub step in the GH workflow.
     set(SYS_LIBS
@@ -66,6 +70,8 @@ if (WIN32)
     )
 else()
     set(ESENTHEL_ENGINE_LIB "${CMAKE_CURRENT_SOURCE_DIR}/Lib/Engine.a")
+    # ENet library for Linux
+    set(ENET_LIB "${CMAKE_CURRENT_SOURCE_DIR}/Lib/libenet.a")
     set(SYS_LIBS                                     # original Linux set
             pthread dl m X11 Xi Xinerama Xrandr Xmu Xcursor Xxf86vm rt
             GL openal z odbc udev
@@ -110,10 +116,10 @@ if (MSVC)
             "/SUBSYSTEM:WINDOWS"
             "/ENTRY:wWinMainCRTStartup")
 
-    target_link_libraries(BasicAppCmake PRIVATE GameCore GameLib)
+    target_link_libraries(BasicAppCmake PRIVATE GameCore GameLib ${ENET_LIB})
 else()
     target_link_libraries(BasicAppCmake PRIVATE
-            GameCore GameLib
+            GameCore GameLib ${ENET_LIB}
             -static-libstdc++ -nopie)
 endif()
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,10 +1,17 @@
 ﻿/******************************************************************************/
 #include "stdafx.h"
+#include <enet/enet.h>
+#include <cstring>
 #include "@@headers.h"
 #include "MyClass.h"
 /******************************************************************************/
 int counter = 0;
 Vec2 dot_pos(0, 0);
+
+ENetHost *gServer = nullptr;
+ENetHost *gClient = nullptr;
+ENetPeer *gPeer   = nullptr;
+bool      gConnected = false;
 /******************************************************************************/
 void InitPre() // initialize before engine inits
 {
@@ -22,12 +29,48 @@ void InitPre() // initialize before engine inits
 bool Init() // initialize after engine is ready
 {
    LogN(S+"Init()");
+
+   if (enet_initialize() != 0)
+   {
+      LogN(S+"Enet init failed");
+      return false;
+   }
+   atexit(enet_deinitialize);
+
+   ENetAddress address;
+   address.host = ENET_HOST_ANY;
+   address.port = 12345;
+   gServer = enet_host_create(&address, 1, 1, 0, 0);
+   if(!gServer)
+   {
+      LogN(S+"Failed to create ENet server");
+      return false;
+   }
+
+   gClient = enet_host_create(NULL, 1, 1, 0, 0);
+   if(!gClient)
+   {
+      LogN(S+"Failed to create ENet client");
+      return false;
+   }
+
+   enet_address_set_host(&address, "127.0.0.1");
+   gPeer = enet_host_connect(gClient, &address, 1, 0);
+   if(!gPeer)
+   {
+      LogN(S+"Failed to start ENet connection");
+      return false;
+   }
+
    return true;
 }
 /******************************************************************************/
 void Shut() // shut down at exit
 {
    LogN(S+"Shut()1111");
+   if(gPeer)   enet_peer_disconnect(gPeer, 0);
+   if(gClient) enet_host_destroy(gClient);
+   if(gServer) enet_host_destroy(gServer);
 }
 /******************************************************************************/
 bool Update() // main updating
@@ -44,6 +87,47 @@ bool Update() // main updating
    if(Kb.b(KB_DOWN )) dot_pos.y -= speed * Time.d();
 
    if(!App.active())Time.wait(1);
+
+   ENetEvent event;
+   while(gServer && enet_host_service(gServer, &event, 0) > 0)
+   {
+      switch(event.type)
+      {
+         case ENET_EVENT_TYPE_CONNECT:
+            LogN(S+"Server: client connected");
+            break;
+         case ENET_EVENT_TYPE_RECEIVE:
+            LogN(S+"Server recv: "+(char*)event.packet->data);
+            enet_packet_destroy(event.packet);
+            break;
+         default: break;
+      }
+   }
+
+   while(gClient && enet_host_service(gClient, &event, 0) > 0)
+   {
+      switch(event.type)
+      {
+         case ENET_EVENT_TYPE_CONNECT:
+            gConnected = true;
+            LogN(S+"Client connected to server");
+            break;
+         case ENET_EVENT_TYPE_RECEIVE:
+            LogN(S+"Client recv: "+(char*)event.packet->data);
+            enet_packet_destroy(event.packet);
+            break;
+         default: break;
+      }
+   }
+
+   if(gConnected && gPeer)
+   {
+      const char *msg = "Hello ENet";
+      ENetPacket *packet = enet_packet_create(msg, strlen(msg)+1, ENET_PACKET_FLAG_RELIABLE);
+      enet_peer_send(gPeer, 0, packet);
+      enet_host_flush(gClient);
+      gConnected = false;
+   }
 
    return true;                   // continue
 }


### PR DESCRIPTION
## Summary
- include third-party headers in GameCore
- link ENet library on both platforms
- spawn ENet server and client in `Main.cpp`
- fix Windows build by including ENet headers before macros

## Testing
- `cmake --preset linux-release` *(failed: The C compiler identification is unknown)*
- `ctest --preset linux-test` *(failed: No tests were found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.