### PR TITLE
Fix ENet include and note build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(GameCore INTERFACE)
 target_include_directories(GameCore INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/Source          # your own headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/Include         # third-party headers
 )
 
 target_include_directories(GameCore SYSTEM INTERFACE
@@ -55,6 +56,11 @@ if (WIN32)
     )
     set(ESENTHEL_ENGINE_LIB EsenthelEngine)
 
+    # ENet static library for Windows
+    add_library(enet STATIC IMPORTED GLOBAL)
+    set_target_properties(enet PROPERTIES
+            IMPORTED_LOCATION "${LIB_DIRECTORY}/enet64.lib")
+
     ## ── Full Windows-SDK + DirectX import-library set (matches old VS cfg) ─
     ##    x3daudio1_7.lib is created by the stub step in the GH workflow.
     set(SYS_LIBS
@@ -66,6 +72,9 @@ if (WIN32)
     )
 else()
     set(ESENTHEL_ENGINE_LIB "${CMAKE_CURRENT_SOURCE_DIR}/Lib/Engine.a")
+    add_library(enet STATIC IMPORTED GLOBAL)
+    set_target_properties(enet PROPERTIES
+            IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/Lib/libenet.a")
     set(SYS_LIBS                                     # original Linux set
             pthread dl m X11 Xi Xinerama Xrandr Xmu Xcursor Xxf86vm rt
             GL openal z odbc udev
@@ -110,10 +119,10 @@ if (MSVC)
             "/SUBSYSTEM:WINDOWS"
             "/ENTRY:wWinMainCRTStartup")
 
-    target_link_libraries(BasicAppCmake PRIVATE GameCore GameLib)
+    target_link_libraries(BasicAppCmake PRIVATE GameCore GameLib enet)
 else()
     target_link_libraries(BasicAppCmake PRIVATE
-            GameCore GameLib
+            GameCore GameLib enet
             -static-libstdc++ -nopie)
 endif()
 

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -1,10 +1,15 @@
 ﻿/******************************************************************************/
 #include "stdafx.h"
+#include <enet/enet.h>
 #include "@@headers.h"
 #include "MyClass.h"
 /******************************************************************************/
 int counter = 0;
 Vec2 dot_pos(0, 0);
+ENetHost* server = nullptr;
+ENetHost* client = nullptr;
+ENetPeer* client_peer = nullptr;
+ENetPeer* server_peer = nullptr;
 /******************************************************************************/
 void InitPre() // initialize before engine inits
 {
@@ -22,12 +27,51 @@ void InitPre() // initialize before engine inits
 bool Init() // initialize after engine is ready
 {
    LogN(S+"Init()");
+   if(enet_initialize() != 0)
+   {
+      LogN(S+"ENet initialization failed");
+      return false;
+   }
+
+   ENetAddress address; // server address
+   address.host = ENET_HOST_ANY;
+   address.port = 12345;
+   server = enet_host_create(&address, 1, 1, 0, 0);
+   if(!server)
+   {
+      LogN(S+"Failed to create ENet server");
+      return false;
+   }
+
+   client = enet_host_create(NULL, 1, 1, 0, 0);
+   if(!client)
+   {
+      LogN(S+"Failed to create ENet client");
+      return false;
+   }
+
+   ENetAddress addr;
+   enet_address_set_host(&addr, "127.0.0.1");
+   addr.port = 12345;
+   client_peer = enet_host_connect(client, &addr, 1, 0);
+   if(!client_peer)
+   {
+      LogN(S+"Failed to initiate ENet connection");
+   }
+
    return true;
 }
 /******************************************************************************/
 void Shut() // shut down at exit
 {
    LogN(S+"Shut()1111");
+   if(client_peer)
+      enet_peer_disconnect_now(client_peer, 0);
+   if(client)
+      enet_host_destroy(client);
+   if(server)
+      enet_host_destroy(server);
+   enet_deinitialize();
 }
 /******************************************************************************/
 bool Update() // main updating
@@ -35,6 +79,47 @@ bool Update() // main updating
    // here you have to process each frame update
    counter = counter + 1;
    LogN(S+"counter: " + counter);
+   ENetEvent event;
+   while(server && enet_host_service(server, &event, 0) > 0)
+   {
+      switch(event.type)
+      {
+         case ENET_EVENT_TYPE_CONNECT:
+            LogN(S+"Server: client connected");
+            server_peer = event.peer;
+            break;
+         case ENET_EVENT_TYPE_RECEIVE:
+            LogN(S+"Server received: " + (const char*)event.packet->data);
+            enet_packet_destroy(event.packet);
+            break;
+         default: break;
+      }
+   }
+
+   while(client && enet_host_service(client, &event, 0) > 0)
+   {
+      switch(event.type)
+      {
+         case ENET_EVENT_TYPE_CONNECT:
+            LogN(S+"Client: connected to server");
+            if(client_peer)
+            {
+               const char msg[] = "hello";
+               ENetPacket* packet = enet_packet_create(msg, sizeof(msg), ENET_PACKET_FLAG_RELIABLE);
+               enet_peer_send(client_peer, 0, packet);
+            }
+            break;
+         case ENET_EVENT_TYPE_RECEIVE:
+            LogN(S+"Client received: " + (const char*)event.packet->data);
+            enet_packet_destroy(event.packet);
+            break;
+         case ENET_EVENT_TYPE_DISCONNECT:
+            LogN(S+"Client disconnected");
+            client_peer = nullptr;
+            break;
+         default: break;
+      }
+   }
    //if(Kb.bp(KB_ESC))return false; // exit if escape on the keyboard pressed
 
    Flt speed = 0.5f; // movement speed


### PR DESCRIPTION
## Summary
- include ENet before redefining built-in types
- unzip Engine assets before configuring

## Testing
- `cmake -B build -S . -DCMAKE_C_COMPILER=/usr/bin/clang-19 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-19` *(fails to download googletest)*

------
https://chatgpt.com/codex/tasks/task_e_683a1c9d5988832880a60fabbce229e6