### PR TITLE
Fix ENet init on Windows debug build

### DIFF
--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -44,7 +44,11 @@ static void SetupEnet()
 
     // ── create server host (32 peers, 2 channels) ──
     ENetAddress addr; addr.port = 12345;
-    addr.host   = ENET_HOST_ANY;          // bind 0.0.0.0
+    //
+    // Binding to the IPv6 "any" address (ENET_HOST_ANY) can fail on some
+    // Windows setups where IPv6 is disabled.  Use an explicit IPv4 address
+    // instead so both release and debug builds behave the same.
+    enet_address_set_host(&addr, "0.0.0.0");    // bind 0.0.0.0
     gServer = enet_host_create(&addr, 32, 2, 0, 0);
     if(!gServer){ LogN("ENet server create failed"); return; }
 


### PR DESCRIPTION
## Summary
- address ENet server creation failure on Windows debug build by binding to IPv4 instead of the IPv6 ANY address

## Testing
- `cmake -S . -B build -DCMAKE_C_COMPILER=/usr/bin/clang-19 -DCMAKE_CXX_COMPILER=/usr/bin/clang++-19` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683b00405e688328817c5f50f9d41824