### PR TITLE
Add standalone ENet server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,3 +87,4 @@ jobs:
           name: BasicAppCmake-${{ matrix.os }}
           path: |
             out/build/${{ matrix.cfg }}/apps/client/client${{ runner.os == 'Windows' && '.exe' || '' }}
+            out/build/${{ matrix.cfg }}/apps/server/server${{ runner.os == 'Windows' && '.exe' || '' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(libs/core)
 add_subdirectory(libs/game)
 add_subdirectory(apps/client)
+add_subdirectory(apps/server)
 
 # allow tests defined in subdirectories
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ cmake --build out/build/<preset>
 ctest --preset linux-test      # run unit tests
 ```
 
-The built application and required *.pak files will appear in `out/build/<preset>/Bin`.
+The built applications and required *.pak files will appear in
+`out/build/<preset>/Bin`.  Two executables are produced:
+
+- `client` – the interactive sample which draws a window and sends a test
+  message using ENet
+- `server` – a small console program which accepts the client's connection and
+  prints any received packets.
 
 NB The engine headers and binaries here are subject to Esenthel / Titan Engine's license:
 ### License

--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -32,7 +32,6 @@ Vec2 dot_pos(0, 0);
 
 /******************************************************************************/
 // ─────────────── ENet globals ───────────────
-static ENetHost *gServer      = nullptr;   // listens on 127.0.0.1:12345
 static ENetHost *gClient      = nullptr;   // connects to the server
 static ENetPeer *gClientPeer  = nullptr;   // client-side handle
 static bool      gEnetReady   = false;     // set true once connected
@@ -44,15 +43,6 @@ static void SetupEnet()
 
     ENetAddress addr{};             // zero-initialise **all** fields
     addr.port = 12345;
-    addr.host = ENET_HOST_ANY;      // or enet_address_set_host_ip(&addr, "::")
-
-    gServer = enet_host_create(&addr, 32, 2, 0, 0);
-
-    if(!gServer){
-        LogN(S+"ENet server create failed.");
-        LogN(S+"ENet server create failed error: " + strerror(errno));
-        return;
-    }
 
     // ── create client host (no binding → will use ephemeral port) ──
     gClient = enet_host_create(nullptr, 1, 2, 0, 0);
@@ -126,7 +116,6 @@ void Shut() // shut down at exit
 {
    LogN(S+"Shut()1111");
     if(gClient) enet_host_destroy(gClient);
-    if(gServer) enet_host_destroy(gServer);
     enet_deinitialize();
 }
 /******************************************************************************/
@@ -144,7 +133,6 @@ bool Update() // main updating
    if(Kb.b(KB_DOWN )) dot_pos.y -= speed * Time.d();
 
     /* ── ENet pump ───────────────────────── */
-    ServiceHost(gServer);
     ServiceHost(gClient);
 
     // send one test packet right after connection succeeds

--- a/apps/server/CMakeLists.txt
+++ b/apps/server/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_executable(server
+    src/server_main.cpp
+)
+
+if(MSVC)
+    target_compile_definitions(server PRIVATE
+        "$<$<CONFIG:Debug>:_ITERATOR_DEBUG_LEVEL=0>"
+        "$<$<CONFIG:Debug>:_HAS_ITERATOR_DEBUGGING=0>"
+    )
+else()
+    target_link_libraries(server PRIVATE -static-libstdc++ -nopie)
+endif()
+
+target_link_libraries(server PRIVATE GameCore)
+

--- a/apps/server/src/server_main.cpp
+++ b/apps/server/src/server_main.cpp
@@ -1,0 +1,59 @@
+#define ENET_IMPLEMENTATION
+#include "enet.h"
+
+#include <iostream>
+#include <cstring>
+#include <csignal>
+
+static ENetHost *gServer = nullptr;
+static bool keepRunning = true;
+
+static void signalHandler(int) {
+    keepRunning = false;
+}
+
+int main(int argc, char **argv)
+{
+    if(enet_initialize() != 0){
+        std::cerr << "ENet init failed" << std::endl;
+        return 1;
+    }
+
+    ENetAddress addr{};
+    addr.host = ENET_HOST_ANY;
+    addr.port = 12345;
+
+    gServer = enet_host_create(&addr, 32, 2, 0, 0);
+    if(!gServer){
+        std::cerr << "ENet server create failed: " << std::strerror(errno) << std::endl;
+        return 1;
+    }
+
+    std::cout << "Server listening on port " << addr.port << std::endl;
+    std::signal(SIGINT, signalHandler);
+
+    ENetEvent e;
+    while(keepRunning){
+        while(enet_host_service(gServer, &e, 100) > 0){
+            switch(e.type){
+                case ENET_EVENT_TYPE_CONNECT:
+                    std::cout << "Client connected" << std::endl;
+                    break;
+                case ENET_EVENT_TYPE_RECEIVE:{
+                    std::string txt((char*)e.packet->data, e.packet->dataLength);
+                    std::cout << "Received: " << txt << std::endl;
+                    enet_packet_destroy(e.packet);
+                    break;}
+                case ENET_EVENT_TYPE_DISCONNECT:
+                    std::cout << "Client disconnected" << std::endl;
+                    break;
+                default: break;
+            }
+        }
+    }
+
+    enet_host_destroy(gServer);
+    enet_deinitialize();
+    std::cout << "Server shut down" << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a new server application
- wire server into root CMake and CI workflow
- document both executables in the README
- adjust client to connect to external server

## Testing
- `cmake --preset linux-release -DFETCHCONTENT_FULLY_DISCONNECTED=ON` *(fails: spdlog::spdlog_header_only not found)*
- `ctest --test-dir out/build/linux-release` *(fails: UnitTests_NOT_BUILT)*

------
https://chatgpt.com/codex/tasks/task_e_683db1edd16c8328abc2a0f168de9971