### PR TITLE
Remove unused server code from client

### DIFF
--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -32,7 +32,6 @@ Vec2 dot_pos(0, 0);
 
 /******************************************************************************/
 // ─────────────── ENet globals ───────────────
-static ENetHost *gServer      = nullptr;   // listens on 127.0.0.1:12345
 static ENetHost *gClient      = nullptr;   // connects to the server
 static ENetPeer *gClientPeer  = nullptr;   // client-side handle
 static bool      gEnetReady   = false;     // set true once connected
@@ -44,15 +43,6 @@ static void SetupEnet()
 
     ENetAddress addr{};             // zero-initialise **all** fields
     addr.port = 12345;
-    addr.host = ENET_HOST_ANY;      // or enet_address_set_host_ip(&addr, "::")
-
-    gServer = enet_host_create(&addr, 32, 2, 0, 0);
-
-    if(!gServer){
-        LogN(S+"ENet server create failed.");
-        LogN(S+"ENet server create failed error: " + strerror(errno));
-        return;
-    }
 
     // ── create client host (no binding → will use ephemeral port) ──
     gClient = enet_host_create(nullptr, 1, 2, 0, 0);
@@ -61,7 +51,7 @@ static void SetupEnet()
     // ── connect client to server on loopback ──
     enet_address_set_host(&addr, "127.0.0.1");
     gClientPeer = enet_host_connect(gClient, &addr, 2, 0);
-    LogN("ENet setup complete, waiting for connect…");
+    LogN("ENet client setup complete, waiting for connect…");
 }
 
 static void ServiceHost(ENetHost *host)
@@ -126,7 +116,6 @@ void Shut() // shut down at exit
 {
    LogN(S+"Shut()1111");
     if(gClient) enet_host_destroy(gClient);
-    if(gServer) enet_host_destroy(gServer);
     enet_deinitialize();
 }
 /******************************************************************************/
@@ -144,7 +133,6 @@ bool Update() // main updating
    if(Kb.b(KB_DOWN )) dot_pos.y -= speed * Time.d();
 
     /* ── ENet pump ───────────────────────── */
-    ServiceHost(gServer);
     ServiceHost(gClient);
 
     // send one test packet right after connection succeeds


### PR DESCRIPTION
## Summary
- strip ENet server setup from the client sample

## Testing
- `cmake --preset linux-release` *(fails: C and C++ compilers not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f660222f88328a88bddfd27cad758