### PR TITLE
Fix ENet initialization cleanup

### DIFF
--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -46,7 +46,11 @@ static void SetupEnet()
 
     // ── create client host (no binding → will use ephemeral port) ──
     gClient = enet_host_create(nullptr, 1, 2, 0, 0);
-    if(!gClient){ LogN("ENet client create failed"); return; }
+    if(!gClient){
+        LogN("ENet client create failed");
+        enet_deinitialize();
+        return;
+    }
 
     // ── connect client to server on loopback ──
     enet_address_set_host(&addr, "127.0.0.1");

--- a/apps/server/src/Main.cpp
+++ b/apps/server/src/Main.cpp
@@ -50,6 +50,7 @@ static void SetupEnet()
     if(!gServer){
         LogN(S+"ENet server create failed.");
         LogN(S+"ENet server create failed error: " + strerror(errno));
+        enet_deinitialize();
         return;
     }
 


### PR DESCRIPTION
## Summary
- clean up ENet initialization if host creation fails

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_C_COMPILER=/usr/bin/clang -DCMAKE_CXX_COMPILER=/usr/bin/clang++`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6840241e2b388328a3ae9c98a5cc0ef6