### PR TITLE
Fix spdlog warnings

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,11 @@ add_executable(UnitTests
 
 target_compile_definitions(UnitTests PRIVATE FMT_USE_FCNTL=0 SPDLOG_FORCE_COLOR=1)
 
+# Suppress spdlog warnings triggered by -ffast-math when using clang
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    target_compile_options(UnitTests PRIVATE -Wno-nan-infinity-disabled)
+endif()
+
 target_link_libraries(UnitTests PRIVATE gtest_main spdlog::spdlog_header_only GameCore GameLib)
 
 if(NOT MSVC)


### PR DESCRIPTION
## Summary
- silence spdlog floating point warnings triggered by `-ffast-math`

## Testing
- `cmake --preset linux-debug`
- `cmake --build out/build/linux-debug --parallel 4`
- `ctest --test-dir out/build/linux-debug --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68402ed0f398832886c0d0229ffb8826