### PR TITLE
Replicate red dots across clients

### DIFF
--- a/apps/server/src/Main.cpp
+++ b/apps/server/src/Main.cpp
@@ -4,6 +4,9 @@
 //     `#include "enet.h"` – put it right above the rest of your includes.
 #define ENET_IMPLEMENTATION
 #include "enet.h"          // ← Header-only ENet (third_party/enet/enet.h)
+
+#include <vector>
+#include <cfloat>
 /******************************************************************************/
 
 #if defined(__linux__)
@@ -35,6 +38,22 @@ Vec2 dot_pos(0, 0);
 static ENetHost *gServer      = nullptr;   // listens on 127.0.0.1:12345
 static Int       clientCount  = 0;
 static Int       packetsRecv  = 0;
+
+struct DotPacket
+{
+    int id;
+    Flt x;
+    Flt y;
+};
+
+struct ClientInfo
+{
+    ENetPeer *peer;
+    int id;
+    Vec2 pos;
+};
+static std::vector<ClientInfo> gClients;
+static int gNextId = 1;
 /******************************************************************************/
 // Local helpers
 static void SetupEnet()
@@ -66,9 +85,30 @@ static void ServiceHost(ENetHost *host)
         switch(e.type)
         {
             case ENET_EVENT_TYPE_CONNECT:
+            {
                 LogN(S+"[ENet] Peer connected, ch:" + int(e.channelID));
+                ClientInfo ci; ci.peer=e.peer; ci.id=gNextId++; ci.pos=Vec2(0,0);
+                gClients.push_back(ci);
+                e.peer->data=(Ptr)(intptr_t)ci.id;
                 ++clientCount;
-            break;
+
+                // notify existing clients about new one
+                DotPacket pkt{ci.id, ci.pos.x, ci.pos.y};
+                for(auto &c:gClients){
+                    ENetPacket *p=enet_packet_create(&pkt,sizeof(pkt),ENET_PACKET_FLAG_RELIABLE);
+                    enet_peer_send(c.peer,0,p);
+                }
+                enet_host_flush(host);
+
+                // send all other clients to the new one
+                for(auto &c:gClients){
+                    if(c.id==ci.id) continue;
+                    DotPacket p2{c.id,c.pos.x,c.pos.y};
+                    ENetPacket *pkt2=enet_packet_create(&p2,sizeof(p2),ENET_PACKET_FLAG_RELIABLE);
+                    enet_peer_send(ci.peer,0,pkt2);
+                }
+                enet_host_flush(host);
+            }break;
 
                 /*
             case ENET_EVENT_TYPE_RECEIVE:
@@ -78,17 +118,38 @@ static void ServiceHost(ENetHost *host)
 
             case ENET_EVENT_TYPE_RECEIVE:
             {
-                Str8 txt((char8*)e.packet->data);          // UTF-8 payload
-                LogN(S + "[ENet] Got pkt (\"" + txt + "\")");
+                if(e.packet->dataLength==sizeof(DotPacket))
+                {
+                    DotPacket pkt; CopyFast(pkt, *(DotPacket*)e.packet->data);
+                    int id=(int)(intptr_t)e.peer->data; pkt.id=id;
+                    for(auto &c:gClients) if(c.id==id){c.pos.set(pkt.x,pkt.y);break;}
+                    for(auto &c:gClients){
+                        ENetPacket *p=enet_packet_create(&pkt,sizeof(pkt),ENET_PACKET_FLAG_UNSEQUENCED);
+                        enet_peer_send(c.peer,0,p);
+                    }
+                    enet_host_flush(host);
+                    ++packetsRecv;
+                }else{
+                    Str8 txt((char8*)e.packet->data);          // UTF-8 payload
+                    LogN(S + "[ENet] Got pkt (\"" + txt + "\")");
+                }
                 enet_packet_destroy(e.packet);
-                ++packetsRecv;
                 break;
             }
 
             case ENET_EVENT_TYPE_DISCONNECT:
+            {
                 LogN("[ENet] Peer disconnected");
+                int id=(int)(intptr_t)e.peer->data;
+                for(auto it=gClients.begin(); it!=gClients.end(); ++it) if(it->id==id){ gClients.erase(it); break; }
+                DotPacket pkt{id, FLT_MAX, FLT_MAX};
+                for(auto &c:gClients){
+                    ENetPacket *p=enet_packet_create(&pkt,sizeof(pkt),ENET_PACKET_FLAG_RELIABLE);
+                    enet_peer_send(c.peer,0,p);
+                }
+                enet_host_flush(host);
                 --clientCount;
-            break;
+            }break;
 
             default: break;
         }


### PR DESCRIPTION
## Summary
- add DotPacket struct and replication tracking to client & server
- broadcast dot positions so all clients see each other
- draw other clients' dots in client

## Testing
- `cmake --preset linux-release`
- `cmake --build out/build/linux-release`
- `ctest --preset linux-test`


------
https://chatgpt.com/codex/tasks/task_e_6840df6ba81483288cc703f9993526b0