### PR TITLE
Fix client disconnect count

### DIFF
--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -144,6 +144,22 @@ bool Init() // initialize after engine is ready
 void Shut() // shut down at exit
 {
    LogN(S+"Shut()1111");
+    if(gClientPeer && gClientPeer->state == ENET_PEER_STATE_CONNECTED)
+    {
+        enet_peer_disconnect(gClientPeer, 0);
+
+        ENetEvent e;
+        // Pump until disconnect confirmation or timeout
+        for(int i=0; i<10 && enet_host_service(gClient, &e, 100) > 0; )
+        {
+            if(e.type == ENET_EVENT_TYPE_DISCONNECT)
+                break;
+            if(e.type == ENET_EVENT_TYPE_RECEIVE)
+                enet_packet_destroy(e.packet);
+            // continue servicing until timeout occurs or disconnect event handled
+        }
+        enet_host_flush(gClient);
+    }
     if(gClient) enet_host_destroy(gClient);
     enet_deinitialize();
 }

--- a/apps/server/src/Main.cpp
+++ b/apps/server/src/Main.cpp
@@ -91,6 +91,8 @@ static void ServiceHost(ENetHost *host)
                 ClientInfo ci; ci.peer=e.peer; ci.id=gNextId++; ci.pos=Vec2(0,0);
                 gClients.push_back(ci);
                 e.peer->data=(Ptr)(intptr_t)ci.id;
+                // shorten timeouts so dropped clients are detected quickly
+                enet_peer_timeout(e.peer, 2, 1000, 2000);
                 ++clientCount;
 
                 // notify existing clients about new one


### PR DESCRIPTION
## Summary
- gracefully disconnect ENet peer from the client
- tighten server peer timeouts so unexpected disconnects are handled quickly

## Testing
- `cmake --build out/build/linux-release --target server client UnitTests`
- `ctest --preset linux-test`


------
https://chatgpt.com/codex/tasks/task_e_6841dcb72e4c832898b0f6a473c606c8