### PR TITLE
Remove duplicate includes and clean up tests

### DIFF
--- a/apps/client/src/ConnectionToServer.h
+++ b/apps/client/src/ConnectionToServer.h
@@ -12,8 +12,6 @@
   #pragma pop_macro("LOCK_WRITE")
   #pragma pop_macro("LOCK_READ")
 #endif
-#include "stdafx.h"
-#include "@@headers.h"
 
 struct _ENetHost; typedef _ENetHost ENetHost;
 struct _ENetPeer; typedef _ENetPeer ENetPeer;

--- a/apps/server/src/ConnectionsToClients.h
+++ b/apps/server/src/ConnectionsToClients.h
@@ -12,8 +12,6 @@
   #pragma pop_macro("LOCK_WRITE")
   #pragma pop_macro("LOCK_READ")
 #endif
-#include "stdafx.h"
-#include "@@headers.h"
 
 struct _ENetHost; typedef _ENetHost ENetHost;
 struct _ENetPeer; typedef _ENetPeer ENetPeer;

--- a/tests/MyClassTests.cpp
+++ b/tests/MyClassTests.cpp
@@ -1,17 +1,12 @@
-#include <iostream>          // << this
 #include "gtest/gtest.h"
 #include "MyClass.h"
 
 TEST(MyClass, GetSetValue) {
-    std::cout << "[MyClass] ctor …\n";
-
     MyClass c("bob", 42);
-    std::cout << "[MyClass] initial value = " << c.getValue() << '\n';
 
     EXPECT_EQ(c.getValue(), 42);
 
     c.setValue(99);
-    std::cout << "[MyClass] after setValue = " << c.getValue() << '\n';
 
     EXPECT_EQ(c.getValue(), 99)
         << "value didn’t update correctly1 ";     // message only if it fails


### PR DESCRIPTION
## Summary
- drop repeated headers from network connection headers
- silence `MyClassTests` by removing `std::cout` calls

## Testing
- `cmake --preset linux-release`
- `cmake --build out/build/linux-release`
- `ctest --preset linux-test`

------
https://chatgpt.com/codex/tasks/task_e_6844a4a44bbc8328ab5bc6b98a3b271a