### PR TITLE
Separate log files for client and server

### DIFF
--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -27,6 +27,7 @@ void InitPre() // initialize before engine inits
    App.background_wait=0;            // no delay when in background
 
     App.name("Client");
+    LogName("log_client.txt");
 
    INIT(); // call auto-generated function that will set up application name, load engine and project data
    LogConsole(true);

--- a/apps/server/src/Main.cpp
+++ b/apps/server/src/Main.cpp
@@ -22,6 +22,7 @@ void InitPre() // initialize before engine inits
    App.background_wait=0;            // no delay when in background
 
     App.name("Server");
+    LogName("log_server.txt");
    INIT(); // call auto-generated function that will set up application name, load engine and project data
    LogConsole(true);
    LogN(S+"InitPre()");


### PR DESCRIPTION
## Summary
- direct each executable's logs to its own file

## Testing
- `cmake --preset linux-release`
- `cmake --build out/build/linux-release`
- `ctest --preset linux-test`

------
https://chatgpt.com/codex/tasks/task_e_6844aa3e88948328950da71f531af782