### PR TITLE
Fix client and server log messages

### DIFF
--- a/apps/client/src/ConnectionToServer.cpp
+++ b/apps/client/src/ConnectionToServer.cpp
@@ -52,7 +52,7 @@ void SetupEnet()
     // ── connect client to server on loopback ──
     enet_address_set_host(&addr, "127.0.0.1");
     gClientPeer = enet_host_connect(gClient, &addr, 2, 0);
-    LogN("ENet client setup complete, waiting for connect…");
+    LogN("ENet client setup complete, waiting for connect...");
 }
 
 void ServiceHost(ENetHost *host)

--- a/apps/client/src/Main.cpp
+++ b/apps/client/src/Main.cpp
@@ -49,7 +49,7 @@ bool Init() // initialize after engine is ready
 /******************************************************************************/
 void Shut() // shut down at exit
 {
-   LogN(S+"Shut()1111");
+   LogN(S+"Shut()");
     if(gClientPeer && gClientPeer->state == ENET_PEER_STATE_CONNECTED)
     {
         enet_peer_disconnect(gClientPeer, 0);

--- a/apps/server/src/ConnectionsToClients.cpp
+++ b/apps/server/src/ConnectionsToClients.cpp
@@ -51,7 +51,7 @@ void SetupEnet()
         return;
     }
 
-    LogN("ENet server setup complete, waiting for clients…");
+    LogN("ENet server setup complete, waiting for clients...");
 }
 
 void ServiceHost(ENetHost *host)

--- a/apps/server/src/Main.cpp
+++ b/apps/server/src/Main.cpp
@@ -38,7 +38,7 @@ bool Init() // initialize after engine is ready
 /******************************************************************************/
 void Shut() // shut down at exit
 {
-   LogN(S+"Shut()1111");
+   LogN(S+"Shut()");
     if(gServer) enet_host_destroy(gServer);
     enet_deinitialize();
 }


### PR DESCRIPTION
## Summary
- update ENet setup logs to avoid non-ASCII ellipsis
- remove stray `1111` from shutdown logs

## Testing
- `ctest --preset linux-test`

------
https://chatgpt.com/codex/tasks/task_e_6844d6a1c17c8328ad50589a45bbc2c5