### PR TITLE
Automate extraction of engine archives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,11 @@
 cmake_minimum_required(VERSION 3.28)
 project(AdvancedCMakeTitanEngineExample LANGUAGES C CXX)
 
+# Extract engine assets/libraries from provided zip archives if needed
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+include(UnpackEngine)
+unpack_engine_files()
+
 # Global compiler settings
 if(MSVC)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded" CACHE STRING "" FORCE)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The project now builds two executables: a **client** sample and a **server** tha
 
 ## Preparing the engine files
 
-The large engine assets and libraries are stored in the repository as zip archives.  Extract them **in place** before configuring the build:
+The large engine assets and libraries are stored in the repository as zip archives.  If the extracted files are missing, CMake will unpack them automatically during configuration:
 
 ```
 assets/Engine.zip            -> assets/Engine.pak
@@ -14,6 +14,9 @@ third_party/EE/Engine64DX11.zip         -> third_party/EE/Engine64DX11.lib      
 third_party/EE/EngineDebug64DX11.zip    -> third_party/EE/EngineDebug64DX11.lib   (Windows debug library)
 third_party/EE/EngineDebug64DX11_pdb.zip-> third_party/EE/EngineDebug64DX11.pdb   (optional debug symbols)
 ```
+
+The configure step automatically unpacks these archives when the extracted
+files are missing, so you normally don't need to run any manual commands.
 
 ## Building
 

--- a/cmake/UnpackEngine.cmake
+++ b/cmake/UnpackEngine.cmake
@@ -1,0 +1,37 @@
+function(unpack_engine_files)
+    set(base "${PROJECT_SOURCE_DIR}")
+    set(assets_dir "${base}/assets")
+    set(ee_dir "${base}/third_party/EE")
+
+    # Engine.pak
+    set(asset_zip "${assets_dir}/Engine.zip")
+    set(asset_file "${assets_dir}/Engine.pak")
+    if(NOT EXISTS "${asset_file}" AND EXISTS "${asset_zip}")
+        message(STATUS "Extracting ${asset_zip}")
+        file(ARCHIVE_EXTRACT INPUT "${asset_zip}" DESTINATION "${assets_dir}")
+    endif()
+
+    set(archives
+        Engine.zip
+        Engine64DX11.zip
+        EngineDebug64DX11.zip
+        EngineDebug64DX11_pdb.zip)
+    set(outputs
+        Engine.a
+        Engine64DX11.lib
+        EngineDebug64DX11.lib
+        EngineDebug64DX11.pdb)
+
+    list(LENGTH archives count)
+    math(EXPR last_index "${count}-1")
+    foreach(i RANGE 0 ${last_index})
+        list(GET archives ${i} archive)
+        list(GET outputs ${i} out_file)
+        set(zip_path "${ee_dir}/${archive}")
+        set(out_path "${ee_dir}/${out_file}")
+        if(NOT EXISTS "${out_path}" AND EXISTS "${zip_path}")
+            message(STATUS "Extracting ${archive}")
+            file(ARCHIVE_EXTRACT INPUT "${zip_path}" DESTINATION "${ee_dir}")
+        endif()
+    endforeach()
+endfunction()


### PR DESCRIPTION
## Summary
- add `UnpackEngine.cmake` helper to extract archives
- automatically unpack engine libraries/assets during configuration
- document automatic unpacking in README

## Testing
- `cmake --preset linux-release`
- `cmake --build out/build/linux-release`
- `ctest --preset linux-test`


------
https://chatgpt.com/codex/tasks/task_e_6845130c78d48328b70097661644b2ab